### PR TITLE
Use correct Id in existing check

### DIFF
--- a/DataTables.AspNetCore.Mvc/GridBuilder.cs
+++ b/DataTables.AspNetCore.Mvc/GridBuilder.cs
@@ -19,7 +19,7 @@ namespace DataTables.AspNetCore.Mvc
         /// <summary>
         /// Initialize a new instance of <see cref="GridBuilder{T}"/>
         /// </summary>
-        public GridBuilder() 
+        public GridBuilder()
         {
             this.Grid = new GridOptions<T>();
         }
@@ -394,7 +394,7 @@ namespace DataTables.AspNetCore.Mvc
             //        document.write('<table id="example" class="display" cellspacing="0" width="100%"></table>')
             //      }
             //</ script >
-            writer.Write($"<script type=\"text/javascript\">if ($(\"{this.Grid.Name}\").length==0){{document.write('<table id=\"{this.Grid.Name}\" class=\"display{(!string.IsNullOrWhiteSpace(this.Grid.ClassName) ? $" {this.Grid.ClassName}" : "")}\" cellspacing=\"0\" width=\"100%\"></table>')}}</script>");
+            writer.Write($"<script type=\"text/javascript\">if ($(\"#{this.Grid.Name}\").length==0){{document.write('<table id=\"{this.Grid.Name}\" class=\"display{(!string.IsNullOrWhiteSpace(this.Grid.ClassName) ? $" {this.Grid.ClassName}" : "")}\" cellspacing=\"0\" width=\"100%\"></table>')}}</script>");
 
             // Datables.Net
             writer.Write("<script>$(function(){");


### PR DESCRIPTION
The check to find if the table exists already with the grid name provided as the Id is incorrect, it needs to be prefixed by # in order to pick up on it.

Current functionality:
If table exists already, another table will be added, but the existing table will be the one the selector picks up on in the next command.  Leaving a stub table at the bottom of the page with the same Id as the existing one.

Expected functionality:
Table is found by the grid name provided and no stub table is added