### PR TITLE
$ is undefined bug

### DIFF
--- a/DataTables.AspNetCore.Mvc/GridBuilder.cs
+++ b/DataTables.AspNetCore.Mvc/GridBuilder.cs
@@ -411,7 +411,8 @@ namespace DataTables.AspNetCore.Mvc
             //        document.write('<table id="example" class="display" cellspacing="0" width="100%"></table>')
             //      }
             //</ script >
-            writer.Write($"<script type=\"text/javascript\">if ($(\"#{this.Grid.Name}\").length==0){{document.write('<table id=\"{this.Grid.Name}\" class=\"display{(!string.IsNullOrWhiteSpace(this.Grid.ClassName) ? $" {this.Grid.ClassName}" : "")}\" cellspacing=\"0\" width=\"100%\"></table>')}}</script>");
+            writer.Write($"<script type=\"text/javascript\">document.addEventListener(\"DOMContentLoaded\", function(event) { if ($(\"#{this.Grid.Name}\").length==0){{document.write('<table id=\"{this.Grid.Name}\" class=\"display{(!string.IsNullOrWhiteSpace(this.Grid.ClassName) ? $" {this.Grid.ClassName}" : "")}\" cellspacing=\"0\" width=\"100%\"></table>')}}});
+</script>");
 
             // Datables.Net
             writer.Write("<script>$(function(){");


### PR DESCRIPTION
The table existence check uses `$`. However, it is not wrapped with a check for when the DOM is ready. 

Hence I have added a check to make sure the dom is loaded first before it begins to create the Datatables object. 

![image](https://user-images.githubusercontent.com/10187133/107848901-bcbd8080-6e10-11eb-9524-7e2d26c23f20.png)

![image](https://user-images.githubusercontent.com/10187133/107848907-c810ac00-6e10-11eb-82a4-9ced19a27f8c.png)
